### PR TITLE
Dynamic virtual_env and python version support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,17 @@
-BLACK=`which black`
+VIRTUAL_ENV ?= venv
+BLACK=$(VIRTUAL_ENV)/bin/black
+PIP=$(VIRTUAL_ENV)/bin/pip
+PYTHON_VERSION=3.6
 
 clean:
-	rm -rf venv
+	rm -rf $(VIRTUAL_ENV)
 	rm -rf __pycache__
 
-virtualenv: clean
-	virtualenv -p python3.6 venv
-	venv/bin/pip install -r requirements.txt
+$(VIRTUAL_ENV):
+	virtualenv -p python$(PYTHON_VERSION) $(VIRTUAL_ENV)
+	$(PIP) install -r requirements.txt
+
+virtualenv: $(VIRTUAL_ENV)
 
 black:
-	$(BLACK) . --exclude venv
+	$(BLACK) . --exclude $(VIRTUAL_ENV)


### PR DESCRIPTION
- Use VIRTUAL_ENV variable for the virtual env name or use 'venv' by default
    `VIRTUAL_ENV ?= venv`
    Usage: make VIRTUAL_ENV=myvirtualenv virtualenv
- Use PYTHON_VERSION variable for creating the virtualenv with a specific python
    version or use 3.6 by default
    Usage: make PYTHON_VERSION=3.7 virtualenv
- Check if there is an existent virtualenv and if it's the case, the job
    will be skipped
- Use the existent black bin from the dynamic virtualenv